### PR TITLE
Support Marionette.Native by not relying on jQuery

### DIFF
--- a/src/vdom-mixin.js
+++ b/src/vdom-mixin.js
@@ -7,7 +7,6 @@ This may be freely distributed under the MIT license.
 */
 'use strict';
 
-var Backbone = require('backbone');
 var _ = require('underscore');
 var diff = require('virtual-dom/diff');
 var patch = require('virtual-dom/patch');
@@ -15,6 +14,14 @@ var convertHTML = require('html-to-vdom')({
   VNode: require('virtual-dom/vnode/vnode'),
   VText: require('virtual-dom/vnode/vtext')
 });
+
+var trim = function( text ) {
+	
+	return text == null ?
+		"" :
+		( text + "" ).replace( /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, "" );
+		
+};
 
 module.exports = function(prototype) {
 
@@ -34,14 +41,14 @@ module.exports = function(prototype) {
 
     attachElContent: function(html) {
       var newVirtualEl = convertHTML(this.rootTemplate({
-        content: Backbone.$.trim(html)
+        content: trim(html)
       }));
       if (this.virtualEl) {
         var patches = diff(this.virtualEl, newVirtualEl);
         patch(this.el, patches);
       }
       else {
-        this.el.innerHTML = Backbone.$.trim(html);
+        this.el.innerHTML = trim(html);
       }
       this.virtualEl = newVirtualEl;
       return this;

--- a/src/vdom-mixin.js
+++ b/src/vdom-mixin.js
@@ -41,7 +41,7 @@ module.exports = function(prototype) {
         patch(this.el, patches);
       }
       else {
-        this.$el.html(Backbone.$.trim(html));
+        this.el.innerHTML = Backbone.$.trim(html);
       }
       this.virtualEl = newVirtualEl;
       return this;


### PR DESCRIPTION
Moving to vanilla to set the innerHTML means Vdom can work with Marionette.Native